### PR TITLE
Fix tasks count in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ types.ts                    # TypeScript definitions
 ## 📖 Learning Path
 
 1. Start with the **Presentation** to understand React 19 concepts
-2. Work through **Tasks 1-5** in order
+2. Work through **Tasks 1-4** in order
 3. Begin each task in the **Work Area**
 4. Reference the **Solution** when needed
 5. Use the sidebar to navigate between tasks and presentation


### PR DESCRIPTION
## Summary
- correct the learning path instructions to reference tasks 1-4

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840485c31d4832695da99fb6b6895cc